### PR TITLE
allow pasing in ssl options for postgres connection

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,10 @@ class KeyvPostgres extends KeyvSql {
 
 		opts.connect = () => Promise.resolve()
 			.then(() => {
-				const pool = new Pool({ connectionString: opts.uri });
+				const pool = new Pool({
+					connectionString: opts.uri,
+					ssl: opts.ssl
+				});
 				return sql => pool.query(sql)
 					.then(data => data.rows);
 			});


### PR DESCRIPTION
This is a fix for DB connections that require SSL to connect (like heroku recently enforced)

It would require you to pass some information to the connection like: 

```
const store = () => new KeyvPostgres({
  uri: 'postgresql://postgres:face@localhost:5432/keyv_test',
  ssl: {
    require: true,
    rejectUnauthorized: false
  }
});
```

This should pass the existing tests, but because the test suite is separated form `keyv-postgres` it seems like this would be impossible to test in the scenario where SSL is required in the PG connection 🤔 

I have an extensive local test to make sure that this worked using Docker so I am confident that it works, I just don't think you can automatically test it given the current setup