### PR TITLE
Update pg to new version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "homepage": "https://github.com/lukechilds/keyv-postgres",
   "dependencies": {
     "@keyv/sql": "1.1.2",
-    "pg": "7.4.1"
+    "pg": "8.7.1"
   },
   "devDependencies": {
     "ava": "^0.24.0",


### PR DESCRIPTION
Old versions of pg don't work with new versions of node.js (14+)